### PR TITLE
Fixed issue #363

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -5,8 +5,13 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, serializers
 from rest_framework.exceptions import ValidationError
 
+from .authentication import JWTAuthentication
 from .settings import api_settings
 from .tokens import RefreshToken, SlidingToken, UntypedToken
+from .utils import datetime_from_epoch
+
+if api_settings.ROTATE_REFRESH_TOKENS:
+    from .token_blacklist.models import OutstandingToken
 
 if api_settings.BLACKLIST_AFTER_ROTATION:
     from .token_blacklist.models import BlacklistedToken
@@ -117,6 +122,17 @@ class TokenRefreshSerializer(serializers.Serializer):
             refresh.set_jti()
             refresh.set_exp()
             refresh.set_iat()
+            
+            # Create OutstandingToken when rotate refresh token
+            auth = JWTAuthentication()
+            user = auth.get_user(validated_token=refresh)
+            OutstandingToken.objects.create(
+                user=user,
+                jti=refresh[api_settings.JTI_CLAIM],
+                token=str(refresh),
+                created_at=refresh.current_time,
+                expires_at=datetime_from_epoch(refresh['exp'])
+            )
 
             data["refresh"] = str(refresh)
 

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -122,7 +122,7 @@ class TokenRefreshSerializer(serializers.Serializer):
             refresh.set_jti()
             refresh.set_exp()
             refresh.set_iat()
-            
+
             # Create OutstandingToken when rotate refresh token
             auth = JWTAuthentication()
             user = auth.get_user(validated_token=refresh)
@@ -131,7 +131,7 @@ class TokenRefreshSerializer(serializers.Serializer):
                 jti=refresh[api_settings.JTI_CLAIM],
                 token=str(refresh),
                 created_at=refresh.current_time,
-                expires_at=datetime_from_epoch(refresh['exp'])
+                expires_at=datetime_from_epoch(refresh["exp"]),
             )
 
             data["refresh"] = str(refresh)


### PR DESCRIPTION
This commit is rewrite from #488
ref: Upon refreshing the token a new Outstanding token is created in the serializers.py where the user from the blacklisted token is added to the new refresh token. This insures that there is always an Outstanding token for each refresh token in use. Therefore, this will solve the issue of logging out from all devices by blacklisting all the Outstanding tokens linked to that specific user.